### PR TITLE
Add background property for Select elements

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -817,6 +817,7 @@ button {
         width: 100%;
         appearance: none;
         -webkit-appearance: none;
+        background: rgba(255, 255, 255, .1);
         position: relative;
     }
 }


### PR DESCRIPTION
Currently, the select button (like the language selector under the real-time view) inherits the browser stylesheet for background color, so it shows as white in dark mode. This commit adds the same background declaration used elsewhere in the app (like on the input element).